### PR TITLE
Don't ignore matchId for json output

### DIFF
--- a/W3ChampionsStatisticService/Matches/Matchup.cs
+++ b/W3ChampionsStatisticService/Matches/Matchup.cs
@@ -16,7 +16,7 @@ namespace W3ChampionsStatisticService.Matches
 
         [JsonPropertyName("id")]
         public string ObjectId => Id.ToString();
-        [JsonIgnore]
+
         public string MatchId { get; set; }
         [JsonIgnore]
         public TimeSpan Duration { get; set; }


### PR DESCRIPTION
Don't ignore matchId for json output
This field is very important to be able to compare ongoing and passed matches